### PR TITLE
Update finemapper.py

### DIFF
--- a/finemapper.py
+++ b/finemapper.py
@@ -811,7 +811,7 @@ class SUSIE_Wrapper(Fine_Mapping):
                     shat=np.ones((m,1)),
                     R=self.df_ld.values,
                     n=self.n,
-                    L=num_causal_snps,
+                    L=num_causal_snps, refine=True, max_iter = 500,
                     scaled_prior_variance=(0.0001 if (prior_var is None) else prior_var),
                     estimate_prior_variance=(prior_var is None),
                     residual_variance=(self.R_null if (residual_var_init is None) else residual_var_init),


### PR DESCRIPTION
increasing the default number of iteration before the IBBS algorithm quits. Default behavior is 200 iterations, but SuSie often needs 500+ iteration in some loci where the LD is strongly correlated. 
There is a new option to set refinement post IBBS convergence comments form the 

```
#' @details The function \code{susie} implements the IBSS algorithm
#' from Wang et al (2020). The option \code{refine = TRUE} implements
#' an additional step to help reduce problems caused by convergence of
#' the IBSS algorithm to poor local optima (which is rare in our
#' experience, but can provide misleading results when it occurs). The
#' refinement step incurs additional computational expense that
#' increases with the number of CSs found in the initial run.

#' @param refine If \code{refine = TRUE}, then an additional
#'  iterative refinement procedure is used, after the IBSS algorithm,
#'  to check and escape from local optima (see details).
```